### PR TITLE
96/sw/story 3789 pnapi image generation exception handling

### DIFF
--- a/lib/exceptional_synchrony/event_machine_proxy.rb
+++ b/lib/exceptional_synchrony/event_machine_proxy.rb
@@ -72,6 +72,18 @@ module ExceptionalSynchrony
       end
     end
 
+    def safe_defer(context, &block)
+      deferrable = EventMachine::DefaultDeferrable.new
+
+      callback = -> (result) { deferrable.succeed(result) }
+
+      EventMachine.defer(nil, callback) { CallbackExceptions.return_exception(&block) }
+
+      EventMachine::Synchrony.sync(deferrable)
+
+      CallbackExceptions.map_deferred_result(deferrable)
+    end
+
     def reactor_running?
       @proxy_class.reactor_running?
     end

--- a/lib/exceptional_synchrony/event_machine_proxy.rb
+++ b/lib/exceptional_synchrony/event_machine_proxy.rb
@@ -72,7 +72,7 @@ module ExceptionalSynchrony
       end
     end
 
-    def safe_defer(context, &block)
+    def defer(context, &block)
       deferrable = EventMachine::DefaultDeferrable.new
 
       callback = -> (result) { deferrable.succeed(result) }

--- a/test/unit/event_machine_proxy_test.rb
+++ b/test/unit/event_machine_proxy_test.rb
@@ -47,6 +47,20 @@ describe ExceptionalSynchrony::EventMachineProxy do
     @em.yield_to_reactor
   end
 
+  describe "#safe_defer" do
+    it "should output its block's output when it doesn't raise an error" do
+      assert_equal 12, @em.safe_defer("#safe_defer success") do
+        12
+      end
+    end
+
+    it "should raise an error when its block raises an error" do
+      assert_raises ArgumentError, @em.safe_defer("#safe_defer raising an error") do
+        raise ArgumentError, "!!!"
+      end
+    end
+  end
+
   EXCEPTION = ArgumentError.new('in block')
 
   describe "blocks should be wrapped in ensure_completely_safe" do

--- a/test/unit/event_machine_proxy_test.rb
+++ b/test/unit/event_machine_proxy_test.rb
@@ -49,14 +49,24 @@ describe ExceptionalSynchrony::EventMachineProxy do
 
   describe "#safe_defer" do
     it "should output its block's output when it doesn't raise an error" do
-      assert_equal 12, @em.safe_defer("#safe_defer success") do
-        12
+      ExceptionHandling.logger = Logger.new(STDERR)
+
+      @em.run do
+        assert_equal 12, @em.safe_defer("#safe_defer success") { 12 }
+        @em.stop
       end
     end
 
     it "should raise an error when its block raises an error" do
-      assert_raises ArgumentError, @em.safe_defer("#safe_defer raising an error") do
-        raise ArgumentError, "!!!"
+      ExceptionHandling.logger = Logger.new(STDERR)
+
+      @em.run do
+        ex = assert_raises(ArgumentError) do
+          @em.safe_defer("#safe_defer raising an error") { raise ArgumentError, "!!!" }
+        end
+
+        assert_equal "!!!", ex.message
+        @em.stop
       end
     end
   end

--- a/test/unit/event_machine_proxy_test.rb
+++ b/test/unit/event_machine_proxy_test.rb
@@ -47,12 +47,12 @@ describe ExceptionalSynchrony::EventMachineProxy do
     @em.yield_to_reactor
   end
 
-  describe "#safe_defer" do
+  describe "#defer" do
     it "should output its block's output when it doesn't raise an error" do
       ExceptionHandling.logger = Logger.new(STDERR)
 
       @em.run do
-        assert_equal 12, @em.safe_defer("#safe_defer success") { 12 }
+        assert_equal 12, @em.defer("#defer success") { 12 }
         @em.stop
       end
     end
@@ -62,7 +62,7 @@ describe ExceptionalSynchrony::EventMachineProxy do
 
       @em.run do
         ex = assert_raises(ArgumentError) do
-          @em.safe_defer("#safe_defer raising an error") { raise ArgumentError, "!!!" }
+          @em.defer("#defer raising an error") { raise ArgumentError, "!!!" }
         end
 
         assert_equal "!!!", ex.message


### PR DESCRIPTION
@ColinDKelley: Thanks again for the help on this! Could you do a quick CR please?

cc @Inanepenguin: `#safe_defer` here may be a better choice than the two in the Web repo, since it returns the result of the deferred work and has a cleaner contract.