### PR TITLE
TECH-1512 make yield_to_reactor no op when reactor isn't running

### DIFF
--- a/lib/exceptional_synchrony/event_machine_proxy.rb
+++ b/lib/exceptional_synchrony/event_machine_proxy.rb
@@ -42,7 +42,9 @@ module ExceptionalSynchrony
     end
 
     def yield_to_reactor
-      @synchrony.sleep(0)
+      if reactor_running?
+        @synchrony.sleep(0)
+      end
     end
 
     def next_tick(&block)

--- a/test/unit/event_machine_proxy_test.rb
+++ b/test/unit/event_machine_proxy_test.rb
@@ -42,9 +42,19 @@ describe ExceptionalSynchrony::EventMachineProxy do
     @yielded_value.must_equal :called
   end
 
-  it "should have a #yield_to_reactor to give control to other threads" do
-    mock(EventMachine::Synchrony).sleep(0)
-    @em.yield_to_reactor
+  describe "#yield_to_reactor" do
+    it "should give control to other threads when the reactor is running" do
+      mock(@em).reactor_running? { true }
+      mock(EventMachine::Synchrony).sleep(0)
+      @em.yield_to_reactor
+    end
+
+    it "should be a no-op if the reactor is not running" do
+      mock(@em).reactor_running? { false }
+      stub(EventMachine::Synchrony).sleep(0) { raise "Should not sleep!" }
+      @em.yield_to_reactor
+    end
+    
   end
 
   describe "#defer" do


### PR DESCRIPTION
This way we can streamline the startup process for PNAPI to initialize the in-memory database before starting the reactor and taking requests. This should prevent the race conditions around startup that are preventing god from starting PNAPI reliably while it's active in the ha_proxy