### PR TITLE
no-jira: Fix FaradayAdapterPatch_v1 name typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 All notable changes to this project will be documented in this file.
 
-## [1.4.0] - 2012-03-08
+## [1.4.1] - 2021-03-09
+### Fixed
+- FaradayAdapterPatch_v1 name typo
+
+## [1.4.0] - 2021-03-08
 ### Added
 - Added use of Thread local variable to indicate when Eventmachine is running using EM::Synchrony
 - Added faraday gem monkey patch to use the new Thread local variable to choose the adapter to use
@@ -29,6 +33,7 @@ All notable changes to this project will be documented in this file.
 ## [1.1.1] - 2020-05-03
 - Replace hobo_support with invoca_utils
 
+[1.4.1]: https://github.com/Invoca/exceptional_synchrony/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/Invoca/exceptional_synchrony/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/Invoca/exceptional_synchrony/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/Invoca/exceptional_synchrony/compare/v1.1.1...v1.2.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    exceptional_synchrony (1.4.0)
+    exceptional_synchrony (1.4.1)
       em-http-request
       em-synchrony
       eventmachine
@@ -89,15 +89,13 @@ GEM
       mini_mime (>= 0.1.1)
     method_source (1.0.0)
     mini_mime (1.0.2)
-    mini_portile2 (2.5.0)
     minitest (5.14.0)
     minitest-reporters (1.4.2)
       ansi
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    nokogiri (1.11.1)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.11.1-x86_64-darwin)
       racc (~> 1.4)
     pry (0.13.1)
       coderay (~> 1.1)

--- a/lib/exceptional_synchrony/faraday_monkey_patch.rb
+++ b/lib/exceptional_synchrony/faraday_monkey_patch.rb
@@ -24,7 +24,7 @@ begin
 
     # Patch built relative to faraday v1.3.0 although the ruby2_keywords prefix
     # was dropped from the adapter method definition to simplify this code
-    module FaradayPatch_v1
+    module FaradayAdapterPatch_v1
       def adapter(klass = NO_ARGUMENT, *args, &block)
         return @adapter if klass == NO_ARGUMENT
 

--- a/lib/exceptional_synchrony/version.rb
+++ b/lib/exceptional_synchrony/version.rb
@@ -1,3 +1,3 @@
 module ExceptionalSynchrony
-  VERSION = '1.4.0'
+  VERSION = '1.4.1'
 end


### PR DESCRIPTION
Fix typo in faraday monkey patch.