### PR TITLE
no-jira: Fix faraday symbol references in FaradayAdapterPatch_v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.2] - 2021-03-10
+### Fixed
+- Additional symbol reference fixes in FaradayAdapterPatch_v1
+
 ## [1.4.1] - 2021-03-09
 ### Fixed
 - FaradayAdapterPatch_v1 name typo
@@ -33,6 +37,7 @@ All notable changes to this project will be documented in this file.
 ## [1.1.1] - 2020-05-03
 - Replace hobo_support with invoca_utils
 
+[1.4.2]: https://github.com/Invoca/exceptional_synchrony/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/Invoca/exceptional_synchrony/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/Invoca/exceptional_synchrony/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/Invoca/exceptional_synchrony/compare/v1.2.0...v1.3.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    exceptional_synchrony (1.4.1)
+    exceptional_synchrony (1.4.2)
       em-http-request
       em-synchrony
       eventmachine
@@ -89,13 +89,15 @@ GEM
       mini_mime (>= 0.1.1)
     method_source (1.0.0)
     mini_mime (1.0.2)
+    mini_portile2 (2.5.0)
     minitest (5.14.0)
     minitest-reporters (1.4.2)
       ansi
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    nokogiri (1.11.1-x86_64-darwin)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     pry (0.13.1)
       coderay (~> 1.1)

--- a/lib/exceptional_synchrony/faraday_monkey_patch.rb
+++ b/lib/exceptional_synchrony/faraday_monkey_patch.rb
@@ -25,8 +25,8 @@ begin
     # Patch built relative to faraday v1.3.0 although the ruby2_keywords prefix
     # was dropped from the adapter method definition to simplify this code
     module FaradayAdapterPatch_v1
-      def adapter(klass = NO_ARGUMENT, *args, &block)
-        return @adapter if klass == NO_ARGUMENT
+      def adapter(klass = Faraday::RackBuilder::NO_ARGUMENT, *args, &block)
+        return @adapter if klass == Faraday::RackBuilder::NO_ARGUMENT
 
         klass = Faraday::Adapter.lookup_middleware(klass) if klass.is_a?(Symbol)
 
@@ -36,7 +36,7 @@ begin
         end
         # END PATCH
 
-        @adapter = self.class::Handler.new(klass, *args, &block)
+        @adapter = Faraday::RackBuilder::Handler.new(klass, *args, &block)
       end
     end
   end

--- a/lib/exceptional_synchrony/version.rb
+++ b/lib/exceptional_synchrony/version.rb
@@ -1,3 +1,3 @@
 module ExceptionalSynchrony
-  VERSION = '1.4.1'
+  VERSION = '1.4.2'
 end


### PR DESCRIPTION
Additional fixes to make sure all symbols are defined. This was verified to work properly with the audio processor in staging when using faraday 1.0.