### PR TITLE
non-production: default unused defer(context) argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.4] - 2022-03-25
+### Changed
+- Default unused defer(context) argument to nil.
+
 ## [1.4.3] - 2022-03-24
 ### Changed
 - Update exception_handling
@@ -41,6 +45,7 @@ All notable changes to this project will be documented in this file.
 ## [1.1.1] - 2020-05-03
 - Replace hobo_support with invoca_utils
 
+[1.4.4]: https://github.com/Invoca/exceptional_synchrony/compare/v1.4.3...v1.4.4
 [1.4.3]: https://github.com/Invoca/exceptional_synchrony/compare/v1.4.2...v1.4.3
 [1.4.2]: https://github.com/Invoca/exceptional_synchrony/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/Invoca/exceptional_synchrony/compare/v1.4.0...v1.4.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    exceptional_synchrony (1.4.3)
+    exceptional_synchrony (1.4.4)
       em-http-request
       em-synchrony
       eventmachine

--- a/lib/exceptional_synchrony/event_machine_proxy.rb
+++ b/lib/exceptional_synchrony/event_machine_proxy.rb
@@ -89,7 +89,7 @@ module ExceptionalSynchrony
     # This method will execute the block on the background thread pool
     # By default, it will block the caller until the background thread has finished, so that the result can be returned
     #  :wait_for_result - setting this to false will prevent the caller from being blocked by this deferred work
-    def defer(context, wait_for_result: true, &block)
+    def defer(_context = nil, wait_for_result: true, &block)
       if wait_for_result
         deferrable = EventMachine::DefaultDeferrable.new
         callback = -> (result) { deferrable.succeed(result) }

--- a/lib/exceptional_synchrony/version.rb
+++ b/lib/exceptional_synchrony/version.rb
@@ -1,3 +1,3 @@
 module ExceptionalSynchrony
-  VERSION = '1.4.3'
+  VERSION = '1.4.4'
 end

--- a/test/unit/event_machine_proxy_test.rb
+++ b/test/unit/event_machine_proxy_test.rb
@@ -102,7 +102,7 @@ describe ExceptionalSynchrony::EventMachineProxy do
 
     it "should output its block's output when it doesn't raise an error, by default" do
       @em.run do
-        assert_equal 12, @em.defer("#defer success") { 12 }
+        assert_equal 12, @em.defer { 12 }
         @em.stop
       end
     end
@@ -111,7 +111,7 @@ describe ExceptionalSynchrony::EventMachineProxy do
       @block_ran = false
 
       @em.run do
-        assert_nil @em.defer("#defer success", wait_for_result: false) { @block_ran = true; 12 }
+        assert_nil @em.defer(wait_for_result: false) { @block_ran = true; 12 }
         refute @block_ran
         stop_em_after_defers_finish!(@em)
       end
@@ -123,7 +123,7 @@ describe ExceptionalSynchrony::EventMachineProxy do
       mock(ExceptionHandling).log_error(is_a(RuntimeError), "defer", {})
 
       @em.run do
-        assert_nil @em.defer("#defer success", wait_for_result: false) { raise RuntimeError, "error in defer" }
+        assert_nil @em.defer(wait_for_result: false) { raise RuntimeError, "error in defer" }
         stop_em_after_defers_finish!(@em)
       end
     end
@@ -131,7 +131,7 @@ describe ExceptionalSynchrony::EventMachineProxy do
     it "should raise an error when its block raises an error" do
       @em.run do
         ex = assert_raises(ArgumentError) do
-          @em.defer("#defer raising an error") { raise ArgumentError, "!!!" }
+          @em.defer { raise ArgumentError, "!!!" }
         end
 
         assert_equal "!!!", ex.message


### PR DESCRIPTION
I noticed that EMP.defer had an unused context argument.

## [1.4.3] - Unreleased
### Changed
- Update exception_handling to 2.10
- Default unused defer(context) argument to nil.