### PR TITLE
non-production: set up codecov in this repo

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,5 +6,6 @@ on:
 jobs:
   tests:
     uses: Invoca/ruby-test-matrix-workflow/.github/workflows/ruby-test-matrix.yml@main
+    secrets: inherit
     with:
       test-command: "bundle exec rake"

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ group :development do
   gem 'rexml'
   gem 'rspec-expectations'
   gem 'rspec-mocks'
+  gem 'simplecov', '~> 0.22'
+  gem 'simplecov-lcov', '~> 0.8'
   gem 'thor'
   gem 'webmock', '~> 1.24'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
       bigdecimal
       rexml
     diff-lcs (1.5.1)
+    docile (1.4.1)
     drb (2.2.1)
     em-http-request (1.1.7)
       addressable (>= 2.3.4)
@@ -89,6 +90,13 @@ GEM
       rspec-support (~> 3.13.0)
     rspec-support (3.13.2)
     ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov-lcov (0.9.0)
+    simplecov_json_formatter (0.1.4)
     stringio (3.1.1)
     strscan (3.1.0)
     thor (1.3.1)
@@ -111,6 +119,8 @@ DEPENDENCIES
   rexml
   rspec-expectations
   rspec-mocks
+  simplecov (~> 0.22)
+  simplecov-lcov (~> 0.8)
   thor
   webmock (~> 1.24)
 

--- a/test/simplecov_helper.rb
+++ b/test/simplecov_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+unless ENV["NO_COVERAGE"] == "true"
+  require "simplecov"
+
+  SimpleCov.start do
+    add_filter "/test/"
+    track_files "lib/**/*.rb"
+
+    if ENV["GITHUB_ACTIONS"]
+      require "simplecov-lcov"
+
+      SimpleCov::Formatter::LcovFormatter.config do |config|
+        config.report_with_single_file = true
+        config.single_report_path = "coverage/lcov.info"
+      end
+
+      formatter SimpleCov::Formatter::LcovFormatter
+    else
+      formatter SimpleCov::Formatter::HTMLFormatter
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+require_relative "simplecov_helper"
+
 ENV['RACK_ENV'] = 'test'
 
 require 'bundler'


### PR DESCRIPTION
## Summary
- Pass secrets: inherit to the shared ruby-test-matrix workflow in .github/workflows/pipeline.yml so the org CODECOV_TOKEN reaches the Codecov upload step
- Add simplecov and simplecov-lcov (Gemfile development group, Gemfile.lock updated) and a test/simplecov_helper.rb required first in test/test_helper.rb, emitting coverage/lcov.info when GITHUB_ACTIONS is set

## Coverage
Measured locally (Ruby 3.1.6, bundle exec rake): 83 tests, 0 failures. Line Coverage: 91.5% (226 / 247).

codecov.yml not added: coverage is above the 80% threshold.